### PR TITLE
added ARC requirement for MMQueuedWormhole

### DIFF
--- a/Source/MMQueuedWormhole.m
+++ b/Source/MMQueuedWormhole.m
@@ -9,6 +9,10 @@
 #import "MMQueuedWormhole.h"
 #import "MMWormhole-Private.h"
 
+#if !__has_feature(objc_arc)
+#error This class requires automatic reference counting
+#endif
+
 @interface MMQueuedWormhole ()
 @property (nonatomic, strong) NSMutableSet *pluralListeners;
 @end


### PR DESCRIPTION
Really important since there is lazy initialized autoreleased pluralListeners which can cause hard-to-find crashes.
